### PR TITLE
Update 2021-02-24-monitors-mac.md

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -83,6 +83,9 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GN950-B</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B</span></div>
+
+
 ## <img src="air_2020.png" height=32> <span>MacBook Air (M1, 2020)</span>
 
 <div class="row"><img src="works.png" height=64> <span>Acer NITRO XV3 (XV273K Pbmiipphzx) only on Monterey</span></div>


### PR DESCRIPTION
added the LG UltraGear 27GN950-B for the Mac Min
<img width="727" alt="screenshot3" src="https://user-images.githubusercontent.com/11780910/141841892-27b0ff3a-5b73-4234-9c56-5f3c900fc8ce.png">
<img width="582" alt="screenshot2" src="https://user-images.githubusercontent.com/11780910/141841898-d534c135-8bac-4f2a-92bf-c552dccb8a9c.png">
<img width="582" alt="screenshot1" src="https://user-images.githubusercontent.com/11780910/141841902-cea7ffa1-5384-4ec2-a100-9544b60e384f.png">
i